### PR TITLE
v1.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
-neoforge_version=21.1.168
+neoforge_version=21.1.181
 kff_version=5.8.0
 cobblemon_version=1.6.1+1.21.1
 counter_version=1.6-neoforge-1.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.2.1
+mod_version=1.6-neoforge-1.2.2
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=unchained
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/UnchainedMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/UnchainedMod.kt
@@ -1,9 +1,8 @@
 package us.timinc.mc.cobblemon.unchained
 
-import net.neoforged.bus.api.SubscribeEvent
-import net.neoforged.fml.common.EventBusSubscriber
+import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import net.neoforged.fml.common.Mod
-import net.neoforged.neoforge.event.server.ServerStartedEvent
 import us.timinc.mc.cobblemon.unchained.modules.HiddenBooster
 import us.timinc.mc.cobblemon.unchained.modules.IvBooster
 import us.timinc.mc.cobblemon.unchained.modules.ShinyBooster
@@ -13,14 +12,9 @@ import us.timinc.mc.cobblemon.unchained.modules.SpawnChainer
 object UnchainedMod {
     @Suppress("unused", "MemberVisibilityCanBePrivate")
     const val MOD_ID = "unchained"
-    var eventsInitialized = false
 
-    @EventBusSubscriber
-    object Registration {
-        @SubscribeEvent
-        fun onInitialize(e: ServerStartedEvent) {
-            if (eventsInitialized) return
-            eventsInitialized = true
+    init {
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) {
             ShinyBooster.initialize()
             HiddenBooster.initialize()
             IvBooster.initialize()

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "unchained"
-version = "1.6-neoforge-1.2.1"
+version = "1.6-neoforge-1.2.2"
 displayName = "Cobblemon Unchained"
 authors = "timinc aka Timothy Metcalfe"
 description = '''


### PR DESCRIPTION
* Moved event handler registration from annotations to init. Change precipitated by an oddity in newer versions of KFF/NF that caused annotation-based event registration to fail (looks like NF removed access to something? idk). This should work across versions.