### PR TITLE
fixed defaultValue and fishing spawner event attachment

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
@@ -4,6 +4,7 @@ import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnAction
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
@@ -18,7 +19,9 @@ object HiddenBooster : AbstractBooster<HiddenBoosterConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { HiddenBoosterInfluence(config, ::debug, it) }
-        fishingSpawner.influences.add(HiddenBoosterInfluence(config, ::debug))
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
+            fishingSpawner.influences.add(HiddenBoosterInfluence(config, ::debug))
+        }
     }
 }
 
@@ -66,7 +69,7 @@ class HiddenBoosterInfluence(
     }
 }
 
-class HiddenBoosterConfig : AbstractBoostConfig(1.0) {
+class HiddenBoosterConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 100
     override val koCountPoints = 1
     override val captureStreakPoints = 0

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
@@ -1,10 +1,12 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
+import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.pokemon.stats.Stat
 import com.cobblemon.mod.common.api.pokemon.stats.Stats
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnAction
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.resources.ResourceLocation
@@ -20,7 +22,9 @@ object IvBooster : AbstractBooster<IvBoosterConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { IvBoosterInfluence(config, ::debug, it) }
-        fishingSpawner.influences.add(IvBoosterInfluence(config, ::debug))
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
+            fishingSpawner.influences.add(IvBoosterInfluence(config, ::debug))
+        }
     }
 }
 
@@ -70,7 +74,7 @@ class IvBoosterInfluence(
     }
 }
 
-class IvBoosterConfig : AbstractBoostConfig(1.0) {
+class IvBoosterConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 0
     override val koCountPoints = 0
     override val captureStreakPoints = 1

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
@@ -21,7 +21,7 @@ object ShinyBooster : AbstractBooster<ShinyBoostConfig>(
     }
 }
 
-class ShinyBoostConfig : AbstractBoostConfig(1.0) {
+class ShinyBoostConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 1
     override val koCountPoints = 0
     override val captureStreakPoints = 0

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
@@ -1,8 +1,10 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
+import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
@@ -15,7 +17,9 @@ object SpawnChainer : AbstractBooster<SpawnChainerConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { SpawnChainerInfluence(config, ::debug) }
-        fishingSpawner.influences.add(SpawnChainerInfluence(config, ::debug))
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
+            fishingSpawner.influences.add(SpawnChainerInfluence(config, ::debug))
+        }
     }
 }
 


### PR DESCRIPTION
* Only Spawn Chainer should have ever had 1.0 as the default defaultValue, as its is multiplicative.
* Had to lower the priority on attaching to the fishing spawner because it attaches *during* server load.
